### PR TITLE
Add Groningen Explorer website

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Groningen Explorer</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <div class="logo">Groningen Explorer</div>
+        <nav>
+            <a href="#landmarks">Landmarks</a>
+            <a href="#gaming">Gaming History</a>
+            <a href="#nightlife">Nightlife</a>
+        </nav>
+    </header>
+    <main>
+        <section id="landmarks">
+            <h1>Discover Groningen</h1>
+            <p>Explore famous sites like the Martini Tower, Ureborg, Stadsschouwburg, Forum, and the Groningen Museum. Don't miss Nisperland 17.</p>
+            <img src="https://upload.wikimedia.org/wikipedia/commons/1/1b/Martini-toren_2009.jpg" alt="Martini Tower" />
+        </section>
+        <section id="gaming">
+            <h2>The Legacy of PlayStation 2</h2>
+            <p>Learn about the history of the PlayStation Tour, the future of the console, and how it stacks up against competitors like the Xbox, Commodore 64, and Nintendo Switch.</p>
+        </section>
+        <section id="nightlife">
+            <h2>Nightlife in Groningen</h2>
+            <p>Discover the vibrant nightlife scene and visit local favorites like Cafeteria Stoepje.</p>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2025 Groningen Explorer</p>
+    </footer>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/website/script.js
+++ b/website/script.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', () => {
+    console.log('Groningen Explorer loaded');
+});

--- a/website/style.css
+++ b/website/style.css
@@ -1,0 +1,43 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f2f2f2;
+}
+header {
+    background-color: #232f3e;
+    color: white;
+    padding: 10px 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+header .logo {
+    font-size: 1.5em;
+    font-weight: bold;
+}
+nav a {
+    color: white;
+    margin-left: 15px;
+    text-decoration: none;
+    font-weight: bold;
+}
+nav a:hover {
+    text-decoration: underline;
+}
+main {
+    max-width: 900px;
+    margin: 20px auto;
+    background-color: white;
+    padding: 20px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+section {
+    margin-bottom: 30px;
+}
+footer {
+    text-align: center;
+    padding: 20px;
+    background-color: #232f3e;
+    color: white;
+}


### PR DESCRIPTION
## Summary
- create `website` directory with simple static site
- add Amazon-like layout and navigation
- describe Groningen landmarks, PlayStation 2, and nightlife

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68684cf27e788329a57dc90e82c31f8f